### PR TITLE
Add CI/CD to FiftyOne Teams Dev

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - 'sy/develop'
+
+env:
+  TAG: ${{ github.sha }}
+  REPO: ${{ github.event.repository.name }}
+
+jobs:
+  deploy-to-dev:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Checkout GitHub Action
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build testable, local app image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: |
+            ${{ env.REPO }}:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          secrets: |
+            "fiftyone_pypi_token=${{ secrets.FIFTYONE_PYPI_TOKEN }}"
+
+      - name: Deploy to dev
+        env:
+          FIFTYONE_API_URI: ${{ vars.FIFTYONE_API_URI }}
+          FIFTYONE_API_KEY: ${{ secrets.FIFTYONE_API_KEY }}
+        run: docker run --rm --entrypoint /bin/bash -e FIFTYONE_API_URI -e FIFTYONE_API_KEY ${{ env.REPO }}:local -c 'make install-labelbox'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-bookworm
+
+RUN apt-get update \
+  && apt-get install -y python3-dev \
+                        gcc \
+                        ffmpeg \
+                        libc-dev \
+                        zip \
+  && apt-get purge --autoremove -y git \
+                                   wget \
+  && apt-get -y upgrade \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# working directory
+WORKDIR /src
+
+# copy requirement file to working directory
+COPY requirements.txt .
+RUN --mount=type=secret,id=fiftyone_pypi_token \
+  FIFTYONE_PYPI_TOKEN=$(cat /run/secrets/fiftyone_pypi_token) \
+  pip install -r requirements.txt
+
+# Fiftyone by default installs a mongo from ubuntu 18.04
+# to run local tests against.  We need to remove that
+# and put a more modern one in there.
+RUN pip uninstall -y fiftyone-db \
+  && pip install fiftyone-db-ubuntu2204 --force-reinstall
+
+# Upgrade FiftyOne DB
+RUN FIFTYONE_DATABASE_ADMIN=true fiftyone migrate --all
+
+COPY . .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+payloads/labelbox.zip: assets/* __init__.py custom_labelbox.py fiftyone.yml
+	rm -rf $@
+	zip -r $@ assets/* __init__.py custom_labelbox.py fiftyone.yml
+
+.PHONY: check-fiftyone-api
+check-fiftyone-api:
+ifndef FIFTYONE_API_URI
+	$(error Environment variable FIFTYONE_API_URI is undefined)
+endif
+ifndef FIFTYONE_API_KEY
+	$(error Environment variable FIFTYONE_API_KEY is undefined)
+endif
+
+.PHONY: install-labelbox
+install-labelbox: payloads/labelbox.zip check-fiftyone-api
+	python -c "import fiftyone.management as fom; fom.upload_plugin('payloads/labelbox.zip', overwrite=True)"
+
+.PHONY: clean-pycache
+clean-pycache:
+	find -name __pycache__ -type d -exec rm -rf {} \;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# FiftyOne Teams
+https://${FIFTYONE_PYPI_TOKEN}@pypi.fiftyone.ai/packages/fiftyone-2.1.1-py3-none-any.whl
+
+labelbox==5.1.0


### PR DESCRIPTION
This PR adds CI/CD so this plugin automatically deploys to FiftyOne Teams Dev when the `sy/develop` branch is updated.

Overview of environment settings in GitHub:
* `dev` environment
* Each environment has environment secret `FIFTYONE_API_KEY` and environment variable `FIFTYONE_API_URI`
* Only `sy/develop` branch can deploy to `dev` environment