### PR TITLE
Add CD to FiftyOne Teams Prod

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - 'sy/main'
+
+env:
+  TAG: ${{ github.sha }}
+  REPO: ${{ github.event.repository.name }}
+
+jobs:
+  deploy-to-prod:
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - name: Checkout GitHub Action
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build testable, local app image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: |
+            ${{ env.REPO }}:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          secrets: |
+            "fiftyone_pypi_token=${{ secrets.FIFTYONE_PYPI_TOKEN }}"
+
+      - name: Deploy to prod
+        env:
+          FIFTYONE_API_URI: ${{ vars.FIFTYONE_API_URI }}
+          FIFTYONE_API_KEY: ${{ secrets.FIFTYONE_API_KEY }}
+        run: docker run --rm --entrypoint /bin/bash -e FIFTYONE_API_URI -e FIFTYONE_API_KEY ${{ env.REPO }}:local -c 'make install-labelbox'


### PR DESCRIPTION
This PR adds a workflow that deploys this plugin to FiftyOne Teams Prod based on the `sy/main` branch. It runs in the `prod` environment defined in this GitHub project, which supplies `FIFTYONE_API_URI` and `FIFTYONE_API_KEY`.