### PR TITLE
Promote secrets injection fix to prod

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -685,6 +685,14 @@ class LoadAnnotations(foo.Operator):
 
 
 def load_annotations(ctx, inputs):
+    if "custom_labelbox" not in fo.annotation_config.backends:
+        fo.annotation_config.backends["custom_labelbox"] = {}
+
+    fo.annotation_config.backends["custom_labelbox"].update({
+        "config_cls": "custom_labelbox.LabelboxBackendConfig",
+        "url": "https://labelbox.com"
+    })
+
     anno_keys = ctx.dataset.list_annotation_runs()
 
     if not anno_keys:
@@ -896,6 +904,14 @@ class DeleteAnnotationRun(foo.Operator):
         foo.execute_operator(self.uri, ctx, params=params)
 
     def resolve_input(self, ctx):
+        if "custom_labelbox" not in fo.annotation_config.backends:
+            fo.annotation_config.backends["custom_labelbox"] = {}
+
+        fo.annotation_config.backends["custom_labelbox"].update({
+            "config_cls": "custom_labelbox.LabelboxBackendConfig",
+            "url": "https://labelbox.com"
+        })
+
         inputs = types.Object()
 
         anno_key = get_anno_key(ctx, inputs, show_default=False)


### PR DESCRIPTION
This PR promotes a [Labelbox secrets injection fix](https://github.com/ehofesmann/fiftyone_labelbox/pull/10) to prod. I did a new round of annotation request and load from [here](https://voxel51.ml.safely-you.cloud/datasets/sprint-review-demo-2024-11-19/samples) to test that this didn't break anything (see field `rszeto_otg_bbox_v2_20250103141943`).